### PR TITLE
run_fpga_task.py: fix deprecation warnings

### DIFF
--- a/openfpga_flow/scripts/run_fpga_task.py
+++ b/openfpga_flow/scripts/run_fpga_task.py
@@ -534,7 +534,7 @@ def strip_child_logger_info(line):
 
 def run_single_script(s, eachJob, job_list):
     with s:
-        thread_name = threading.currentThread().getName()
+        thread_name = threading.current_thread().name
         eachJob["starttime"] = time.time()
         try:
             logfile = "%s_out.log" % thread_name


### PR DESCRIPTION
Python function `currentThread()` and  `getName()` are deprecated.